### PR TITLE
Remove CircleCI from supported CI system

### DIFF
--- a/pages/servers.md
+++ b/pages/servers.md
@@ -11,11 +11,6 @@ List of servers (in alphabetical order) that provide a CCTray feed:
 * Server home: <https://www.buddybuild.com/>
 * CCMenu setup instructions: <http://docs.buddybuild.com/docs/ccmenu>
 
-### CircleCI
-
-* Server home: <https://circleci.com/>
-* CCMenu setup instructions: <https://circleci.com/docs/polling-project-status>
-
 ### CruiseControl
 
 * Server home: <http://cruisecontrol.sourceforge.net/>


### PR DESCRIPTION
CircleCI 2.0 removed support for outputting CCTray XML format. Since CircleCI 1.0 also gone into EOL since Aug 31, 2018, there's currently no way to pull down CircleCI build statuses.

https://github.com/circleci/circleci-docs/blob/b7c84ef8723a328ff00fd215c8e06104b7c5b4b8/jekyll/_archive/polling-project-status.md
(noticed the "archived" in path)

https://circleci.com/blog/sunsetting-1-0/