### PR TITLE
Jenkins 2.173+ now requires plugin to be installed

### DIFF
--- a/pages/servers.md
+++ b/pages/servers.md
@@ -56,6 +56,7 @@ List of servers (in alphabetical order) that provide a CCTray feed:
 
 * Server home: <http://jenkins-ci.org/>
 * Default feed location: `/cc.xml` or `/hudson/cc.xml`
+* Jenkins version 2.173+ needs to install CCtray XML Plugin: https://plugins.jenkins.io/cctray-xml
 * CCMenu autodetect feed URL: supported
 * Note: If you have problems with authentication, please check that you have CCMenu 1.9 or newer.
 


### PR DESCRIPTION
According to CHANGELOG, Jenkins 2.173+ no longer ship with CCtray compatible XML file. Users are advised to install CCtray XML Plugin to restore the functionality.

https://jenkins.io/changelog/#v2.173
https://plugins.jenkins.io/cctray-xml
https://issues.jenkins-ci.org/browse/JENKINS-40750