### PR TITLE
Add Buildkite to the list of supported servers

### DIFF
--- a/pages/servers.md
+++ b/pages/servers.md
@@ -6,6 +6,12 @@ permalink: /servers/
 
 List of servers (in alphabetical order) that provide a CCTray feed:
 
+### Buildkite
+
+* Server home: <https://buildkite.com/>
+* Default feed location: `https://cc.buildkite.com/[org_slug].xml?access_token=[access_token]`
+* CCMenu setup instructions: <https://buildkite.com/docs/integrations/cc-menu>
+
 ### Buddybuild
 
 * Server home: <https://www.buddybuild.com/>


### PR DESCRIPTION
Buildkite has supported CCTray feeds since the beginning, but it was just pointed out to me we weren't on this list. This adds Buildkite to the list of supported servers.

I believe the list in in alphabetical order, and followed the same conventions. But let me know if you'd like any changes.