### PR TITLE
add Woopecker CI server

### DIFF
--- a/pages/servers.md
+++ b/pages/servers.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Servers"
 date: 2019-04-17 00:00:00 +0000
-updated: 2023-05-08 00:00:00 +0000
+updated: 2023-05-29 00:00:00 +0000
 permalink: /servers/
 ---
 
@@ -98,6 +98,11 @@ List of servers (in alphabetical order) that provide a CCTray feed.
 
 * Default feed location `https://api.travis-ci.org/repositories/{user}/{repo}/cc.xml`
 * [Travis CI CCTray documentation](https://docs.travis-ci.com/user/cc-menu/)
+
+### [Woodpecker CI](https://woodpecker-ci.org/)
+
+* Default feed location `/api/badges/{owner}/{repo}/cc.xml`
+  * Example: [https://ci.woodpecker-ci.org/api/badges/woodpecker-ci/woodpecker/cc.xml](https://ci.woodpecker-ci.org/api/badges/woodpecker-ci/woodpecker/cc.xml)
 
 ## Unsupported
 


### PR DESCRIPTION
I would like to add the Woodpecker CI to the cctray supporting server list.
That said, I have to admit, I'm not a maintainer of Woodpecker, but think it's in their interest.

I recently contributed to Woodpecker, so I know the cctray API is present,
and would love to help spread the word (despite its missing documentation).
The provided links prove its working.

@qwerty287 I hope that is in your interest, please veto, if not.